### PR TITLE
feat(infra): Terraform skeleton (ap-south-1) — VPC stub + S3 models/archives

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -1,0 +1,22 @@
+name: Terraform Validate
+
+on:
+  push:
+    paths: ["infra/terraform/**", ".github/workflows/terraform-validate.yml"]
+  pull_request:
+    paths: ["infra/terraform/**", ".github/workflows/terraform-validate.yml"]
+
+jobs:
+  fmt_validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+      - name: Terraform fmt (check)
+        run: terraform fmt -check -recursive
+      - name: Terraform init (no backend)
+        working-directory: infra/terraform
+        run: terraform init -backend=false
+      - name: Terraform validate
+        working-directory: infra/terraform
+        run: terraform validate -no-color

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -1,4 +1,6 @@
 name: Terraform Validate
+permissions:
+  contents: read
 
 on:
   push:
@@ -10,8 +12,10 @@ jobs:
   fmt_validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: hashicorp/setup-terraform@v3
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
       - name: Terraform fmt (check)
         run: terraform fmt -check -recursive
       - name: Terraform init (no backend)

--- a/infra/terraform/.terraform.lock.hcl
+++ b/infra/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,0 +1,20 @@
+# Terraform Infra Skeleton
+
+> AWS region defaults to **ap-south-1 (Mumbai)**. This skeleton provides:
+> - A cost-safe VPC stub (VPC + public/private subnets, IGW; NAT disabled by default).
+> - Two S3 buckets: **models** (versioned) and **archives** (versioned + lifecycle to Glacier/Deep Archive).
+> - Parameterized variables and global tags.
+
+## Safety
+**No apply in CI.** Only `terraform fmt` and `terraform validate` are run. NAT is **off** by default to avoid accidental spend.
+
+## Usage (local)
+```bash
+cd infra/terraform
+terraform init -backend=false
+terraform validate
+```
+
+## Naming
+
+S3 names must be globally unique. Adjust `name_suffix` in `terraform.tfvars` before any real apply.

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,35 @@
+locals {
+  global_tags = merge(
+    {
+      Project     = var.project
+      Environment = var.environment
+      ManagedBy   = "terraform"
+    },
+    var.tags
+  )
+}
+
+module "vpc" {
+  source               = "./modules/vpc"
+  project              = var.project
+  environment          = var.environment
+  vpc_cidr             = var.vpc_cidr
+  az_count             = var.az_count
+  public_subnet_cidrs  = var.public_subnet_cidrs
+  private_subnet_cidrs = var.private_subnet_cidrs
+  enable_nat_gateway   = var.enable_nat_gateway
+  tags                 = local.global_tags
+}
+
+module "storage" {
+  source                     = "./modules/storage"
+  project                    = var.project
+  environment                = var.environment
+  models_bucket_name         = "${var.project}-${var.environment}-models-${var.name_suffix}"
+  archives_bucket_name       = "${var.project}-${var.environment}-archives-${var.name_suffix}"
+  sse_kms_key_arn            = var.s3_kms_key_arn
+  archives_transition_days   = var.archives_transition_days
+  archives_deep_archive_days = var.archives_deep_archive_days
+  archives_expiration_days   = var.archives_expiration_days
+  tags                       = local.global_tags
+}

--- a/infra/terraform/modules/storage/README.md
+++ b/infra/terraform/modules/storage/README.md
@@ -1,0 +1,4 @@
+Two S3 buckets:
+
+* models: versioned, encrypted
+* archives: versioned, encrypted, lifecycle to Glacier/Deep Archive

--- a/infra/terraform/modules/storage/main.tf
+++ b/infra/terraform/modules/storage/main.tf
@@ -1,0 +1,124 @@
+locals {
+  tags = merge(var.tags, { Component = "storage" })
+}
+
+# MODELS bucket (versioned, encrypted)
+
+resource "aws_s3_bucket" "models" {
+  bucket = var.models_bucket_name
+  tags   = merge(local.tags, { Name = var.models_bucket_name, Purpose = "models" })
+}
+
+resource "aws_s3_bucket_ownership_controls" "models" {
+  bucket = aws_s3_bucket.models.id
+  rule { object_ownership = "BucketOwnerEnforced" }
+}
+
+resource "aws_s3_bucket_public_access_block" "models" {
+  bucket                  = aws_s3_bucket.models.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_versioning" "models" {
+  bucket = aws_s3_bucket.models.id
+  versioning_configuration { status = "Enabled" }
+}
+
+# Encryption: AES256 or KMS
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "models_aes" {
+  count  = var.sse_kms_key_arn == null ? 1 : 0
+  bucket = aws_s3_bucket.models.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "models_kms" {
+  count  = var.sse_kms_key_arn == null ? 0 : 1
+  bucket = aws_s3_bucket.models.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = var.sse_kms_key_arn
+    }
+  }
+}
+
+# ARCHIVES bucket (versioned, lifecycle to Glacier/Deep Archive, encrypted)
+
+resource "aws_s3_bucket" "archives" {
+  bucket = var.archives_bucket_name
+  tags   = merge(local.tags, { Name = var.archives_bucket_name, Purpose = "archives" })
+}
+
+resource "aws_s3_bucket_ownership_controls" "archives" {
+  bucket = aws_s3_bucket.archives.id
+  rule { object_ownership = "BucketOwnerEnforced" }
+}
+
+resource "aws_s3_bucket_public_access_block" "archives" {
+  bucket                  = aws_s3_bucket.archives.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_versioning" "archives" {
+  bucket = aws_s3_bucket.archives.id
+  versioning_configuration { status = "Enabled" }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "archives_aes" {
+  count  = var.sse_kms_key_arn == null ? 1 : 0
+  bucket = aws_s3_bucket.archives.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "archives_kms" {
+  count  = var.sse_kms_key_arn == null ? 0 : 1
+  bucket = aws_s3_bucket.archives.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = var.sse_kms_key_arn
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "archives" {
+  bucket = aws_s3_bucket.archives.id
+
+  rule {
+    id     = "archive-tiering"
+    status = "Enabled"
+
+    transition {
+      days          = var.archives_transition_days
+      storage_class = "GLACIER"
+    }
+
+    transition {
+      days          = var.archives_deep_archive_days
+      storage_class = "DEEP_ARCHIVE"
+    }
+
+    dynamic "expiration" {
+      for_each = var.archives_expiration_days > 0 ? [1] : []
+      content {
+        days = var.archives_expiration_days
+      }
+    }
+
+  }
+}

--- a/infra/terraform/modules/storage/outputs.tf
+++ b/infra/terraform/modules/storage/outputs.tf
@@ -1,0 +1,7 @@
+output "models_bucket" {
+  value = aws_s3_bucket.models.bucket
+}
+
+output "archives_bucket" {
+  value = aws_s3_bucket.archives.bucket
+}

--- a/infra/terraform/modules/storage/variables.tf
+++ b/infra/terraform/modules/storage/variables.tf
@@ -1,0 +1,12 @@
+variable "project" { type = string }
+variable "environment" { type = string }
+variable "models_bucket_name" { type = string }
+variable "archives_bucket_name" { type = string }
+variable "sse_kms_key_arn" {
+  type    = string
+  default = null
+}
+variable "archives_transition_days" { type = number }
+variable "archives_deep_archive_days" { type = number }
+variable "archives_expiration_days" { type = number }
+variable "tags" { type = map(string) }

--- a/infra/terraform/modules/vpc/README.md
+++ b/infra/terraform/modules/vpc/README.md
@@ -1,0 +1,1 @@
+Minimal VPC (DNS on, IGW, public+private subnets). NAT is optional (off by default).

--- a/infra/terraform/modules/vpc/main.tf
+++ b/infra/terraform/modules/vpc/main.tf
@@ -1,0 +1,106 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+
+  # Stabilize ordering for first public subnet (index "0")
+
+  public_cidrs  = { for idx, cidr in var.public_subnet_cidrs : tostring(idx) => cidr if idx < var.az_count }
+  private_cidrs = { for idx, cidr in var.private_subnet_cidrs : tostring(idx) => cidr if idx < var.az_count }
+  tags = merge(var.tags, {
+    Component = "vpc"
+  })
+}
+
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  tags = merge(local.tags, {
+    Name = "${var.project}-${var.environment}-vpc"
+  })
+}
+
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.this.id
+  tags   = merge(local.tags, { Name = "${var.project}-${var.environment}-igw" })
+}
+
+# Public subnets
+
+resource "aws_subnet" "public" {
+  for_each                = local.public_cidrs
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = each.value
+  availability_zone       = data.aws_availability_zones.available.names[tonumber(each.key)]
+  map_public_ip_on_launch = true
+  tags = merge(local.tags, {
+    Name = "${var.project}-${var.environment}-public-${each.key}"
+    Tier = "public"
+  })
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+  tags   = merge(local.tags, { Name = "${var.project}-${var.environment}-rtb-public" })
+}
+
+resource "aws_route" "public_internet" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.igw.id
+}
+
+resource "aws_route_table_association" "public_assoc" {
+  for_each       = aws_subnet.public
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.public.id
+}
+
+# Private subnets
+
+resource "aws_subnet" "private" {
+  for_each          = local.private_cidrs
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = each.value
+  availability_zone = data.aws_availability_zones.available.names[tonumber(each.key)]
+  tags = merge(local.tags, {
+    Name = "${var.project}-${var.environment}-private-${each.key}"
+    Tier = "private"
+  })
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.this.id
+  tags   = merge(local.tags, { Name = "${var.project}-${var.environment}-rtb-private" })
+}
+
+# Optional NAT (disabled by default to avoid cost)
+
+resource "aws_eip" "nat" {
+  count  = var.enable_nat_gateway ? 1 : 0
+  domain = "vpc"
+  tags   = merge(local.tags, { Name = "${var.project}-${var.environment}-eip-nat" })
+}
+
+resource "aws_nat_gateway" "nat" {
+  count         = var.enable_nat_gateway ? 1 : 0
+  allocation_id = aws_eip.nat[0].id
+  subnet_id     = aws_subnet.public["0"].id
+  tags          = merge(local.tags, { Name = "${var.project}-${var.environment}-nat" })
+  depends_on    = [aws_internet_gateway.igw]
+}
+
+resource "aws_route" "private_default_via_nat" {
+  count                  = var.enable_nat_gateway ? 1 : 0
+  route_table_id         = aws_route_table.private.id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.nat[0].id
+}
+
+resource "aws_route_table_association" "private_assoc" {
+  for_each       = aws_subnet.private
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.private.id
+}

--- a/infra/terraform/modules/vpc/outputs.tf
+++ b/infra/terraform/modules/vpc/outputs.tf
@@ -1,0 +1,11 @@
+output "vpc_id" {
+  value = aws_vpc.this.id
+}
+
+output "public_subnet_ids" {
+  value = [for s in aws_subnet.public : s.id]
+}
+
+output "private_subnet_ids" {
+  value = [for s in aws_subnet.private : s.id]
+}

--- a/infra/terraform/modules/vpc/variables.tf
+++ b/infra/terraform/modules/vpc/variables.tf
@@ -1,0 +1,8 @@
+variable "project" { type = string }
+variable "environment" { type = string }
+variable "vpc_cidr" { type = string }
+variable "az_count" { type = number }
+variable "public_subnet_cidrs" { type = list(string) }
+variable "private_subnet_cidrs" { type = list(string) }
+variable "enable_nat_gateway" { type = bool }
+variable "tags" { type = map(string) }

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,0 +1,24 @@
+output "vpc_id" {
+  value       = module.vpc.vpc_id
+  description = "VPC ID."
+}
+
+output "public_subnet_ids" {
+  value       = module.vpc.public_subnet_ids
+  description = "Public subnet IDs."
+}
+
+output "private_subnet_ids" {
+  value       = module.vpc.private_subnet_ids
+  description = "Private subnet IDs."
+}
+
+output "models_bucket" {
+  value       = module.storage.models_bucket
+  description = "Models bucket name."
+}
+
+output "archives_bucket" {
+  value       = module.storage.archives_bucket
+  description = "Archives bucket name."
+}

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -1,0 +1,19 @@
+project      = "vaayutrade"
+environment  = "dev"
+region       = "ap-south-1"
+name_suffix  = "tapish"   # <-- change to your initials or a unique token
+
+# VPC
+
+vpc_cidr             = "10.20.0.0/16"
+az_count             = 2
+public_subnet_cidrs  = ["10.20.0.0/24", "10.20.1.0/24"]
+private_subnet_cidrs = ["10.20.10.0/24", "10.20.11.0/24"]
+enable_nat_gateway   = false
+
+# S3
+
+s3_kms_key_arn              = null
+archives_transition_days    = 30
+archives_deep_archive_days  = 180
+archives_expiration_days    = 1095

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,89 @@
+variable "project" {
+  description = "Project slug used in names and tags."
+  type        = string
+  default     = "vaayutrade"
+}
+
+variable "environment" {
+  description = "Deployment environment."
+  type        = string
+  default     = "dev"
+  validation {
+    condition     = contains(["dev", "stage", "prod"], var.environment)
+    error_message = "environment must be one of dev, stage, prod."
+  }
+}
+
+variable "region" {
+  description = "AWS region."
+  type        = string
+  default     = "ap-south-1"
+}
+
+variable "name_suffix" {
+  description = "A short, human-set suffix to keep bucket names globally-unique (e.g., your initials)."
+  type        = string
+  default     = "local"
+}
+
+variable "tags" {
+  description = "Additional tags to apply to all resources."
+  type        = map(string)
+  default     = {}
+}
+
+# VPC parameters (cost-safe stub)
+variable "vpc_cidr" {
+  description = "VPC CIDR."
+  type        = string
+  default     = "10.20.0.0/16"
+}
+
+variable "az_count" {
+  description = "How many AZs to spread subnets across."
+  type        = number
+  default     = 2
+}
+
+variable "public_subnet_cidrs" {
+  description = "CIDRs for public subnets."
+  type        = list(string)
+  default     = ["10.20.0.0/24", "10.20.1.0/24"]
+}
+
+variable "private_subnet_cidrs" {
+  description = "CIDRs for private subnets."
+  type        = list(string)
+  default     = ["10.20.10.0/24", "10.20.11.0/24"]
+}
+
+variable "enable_nat_gateway" {
+  description = "Create a NAT Gateway (costs $$). Default off."
+  type        = bool
+  default     = false
+}
+
+# Storage parameters
+variable "s3_kms_key_arn" {
+  description = "Optional KMS key ARN for bucket encryption; if null, use SSE-S3 (AES256)."
+  type        = string
+  default     = null
+}
+
+variable "archives_transition_days" {
+  description = "Days before transitioning archives to GLACIER."
+  type        = number
+  default     = 30
+}
+
+variable "archives_deep_archive_days" {
+  description = "Days before transitioning archives to DEEP_ARCHIVE."
+  type        = number
+  default     = 180
+}
+
+variable "archives_expiration_days" {
+  description = "Expire archived objects after N days (e.g., 3 years = 1095). Set 0 to disable."
+  type        = number
+  default     = 1095
+}

--- a/infra/terraform/versions.tf
+++ b/infra/terraform/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}


### PR DESCRIPTION
## Summary
- add Terraform root and modules for VPC and storage
- include S3 models and archives buckets with lifecycle
- default region ap-south-1 with parameterized variables and tags
- add GitHub Action to run terraform fmt and validate
- NAT disabled by default to avoid cost

## Testing
- `terraform fmt -recursive`
- `terraform init -backend=false`
- `terraform validate -no-color`

## Checklist
- [x] Root + modules added (VPC, storage)
- [x] S3 models + archives buckets (versioned, encrypted; archives lifecycle)
- [x] ap-south-1 default; parameterized variables and tags
- [x] CI runs `terraform fmt` and `terraform validate` only (no apply)
- [x] NAT disabled by default to avoid cost


------
https://chatgpt.com/codex/tasks/task_e_68aef9bee1748330a5a4f38df367189e